### PR TITLE
Update privacy policy links to the site page

### DIFF
--- a/.changeset/stupid-apricots-punch.md
+++ b/.changeset/stupid-apricots-punch.md
@@ -1,0 +1,5 @@
+---
+"@inialum/memories-react": patch
+---
+
+Update privacy policy links to the site page

--- a/packages/react/src/components/Footer/Footer.tsx
+++ b/packages/react/src/components/Footer/Footer.tsx
@@ -87,9 +87,7 @@ export const Footer = ({ className, ...rest }: Props) => {
 						役員一覧
 					</a>
 					<a
-						href="https://inialum.notion.site/d8a7e0dd14224c0dadfd630a6665cee0"
-						target="_blank"
-						rel="noreferrer noopener"
+						href="https://inialum.org/privacy-policy"
 					>
 						プライバシーポリシー
 					</a>

--- a/packages/react/src/components/Footer/Footer.tsx
+++ b/packages/react/src/components/Footer/Footer.tsx
@@ -86,11 +86,7 @@ export const Footer = ({ className, ...rest }: Props) => {
 					>
 						役員一覧
 					</a>
-					<a
-						href="https://inialum.org/privacy-policy"
-					>
-						プライバシーポリシー
-					</a>
+					<a href="https://inialum.org/privacy-policy">プライバシーポリシー</a>
 					<a
 						href="https://github.com/inialum"
 						target="_blank"

--- a/packages/react/src/components/Navigation/Navigation.tsx
+++ b/packages/react/src/components/Navigation/Navigation.tsx
@@ -161,9 +161,7 @@ const NavigationContent = ({
 								役員一覧
 							</a>
 							<a
-								href="https://inialum.notion.site/d8a7e0dd14224c0dadfd630a6665cee0"
-								target="_blank"
-								rel="noreferrer noopener"
+								href="https://inialum.org/privacy-policy"
 							>
 								プライバシーポリシー
 							</a>

--- a/packages/react/src/components/Navigation/Navigation.tsx
+++ b/packages/react/src/components/Navigation/Navigation.tsx
@@ -160,9 +160,7 @@ const NavigationContent = ({
 							>
 								役員一覧
 							</a>
-							<a
-								href="https://inialum.org/privacy-policy"
-							>
+							<a href="https://inialum.org/privacy-policy">
 								プライバシーポリシー
 							</a>
 							<a


### PR DESCRIPTION
## Summary
- Update the privacy policy link in the footer to point to `https://inialum.org/privacy-policy`
- Update the privacy policy link in the navigation menu to use the same site URL
- Remove external-link attributes that are no longer needed for this internal destination

## Testing
- Not run (not requested)