### PR TITLE
Fix privacy policy links to open in a new tab

### DIFF
--- a/.changeset/tasty-chicken-play.md
+++ b/.changeset/tasty-chicken-play.md
@@ -1,0 +1,5 @@
+---
+"@inialum/memories-react": patch
+---
+
+Fix privacy policy links to open in a new tab

--- a/packages/react/src/components/Footer/Footer.tsx
+++ b/packages/react/src/components/Footer/Footer.tsx
@@ -86,7 +86,13 @@ export const Footer = ({ className, ...rest }: Props) => {
 					>
 						役員一覧
 					</a>
-					<a href="https://inialum.org/privacy-policy">プライバシーポリシー</a>
+					<a
+						href="https://inialum.org/privacy-policy"
+						target="_blank"
+						rel="noreferrer noopener"
+					>
+						プライバシーポリシー
+					</a>
 					<a
 						href="https://github.com/inialum"
 						target="_blank"

--- a/packages/react/src/components/Navigation/Navigation.tsx
+++ b/packages/react/src/components/Navigation/Navigation.tsx
@@ -160,7 +160,11 @@ const NavigationContent = ({
 							>
 								役員一覧
 							</a>
-							<a href="https://inialum.org/privacy-policy">
+							<a
+								href="https://inialum.org/privacy-policy"
+								target="_blank"
+								rel="noreferrer noopener"
+							>
 								プライバシーポリシー
 							</a>
 							<a


### PR DESCRIPTION
## Summary
- Restore `target="_blank"` on the privacy policy link in the footer
- Restore `target="_blank"` on the privacy policy link in the navigation menu
- Keep `rel="noreferrer noopener"` aligned with the other external links

## Testing
- Not run (not requested)